### PR TITLE
Potential fixes for 2 code scanning alerts

### DIFF
--- a/routes/showProductReviews.ts
+++ b/routes/showProductReviews.ts
@@ -31,7 +31,7 @@ module.exports = function productReviews () {
 
     // Measure how long the query takes, to check if there was a nosql dos attack
     const t0 = new Date().getTime()
-    db.reviewsCollection.find({ $where: 'this.product == ' + id }).then((reviews: Review[]) => {
+    db.reviewsCollection.find({ product: id }).then((reviews: Review[]) => {
       const t1 = new Date().getTime()
       challengeUtils.solveIf(challenges.noSqlCommandChallenge, () => { return (t1 - t0) > 2000 })
       const user = security.authenticatedUsers.from(req)

--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -14,7 +14,7 @@ module.exports = function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : req.params.id
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fixes for 2 code scanning alerts from the [Critical CodeQL alert](https://github.com/orgs/GeekMasherOrg/security/campaigns/5) security campaign:
- https://github.com/GeekMasherOrg/juice-shop/security/code-scanning/10
To fix the problem, we should avoid using the `$where` operator with user input. Instead, we can use a parameterized query to safely include the user input in the query. This approach prevents code injection by treating the user input as a value rather than executable code.

  We will replace the `$where` query with a standard query using the `orderId` field. This change ensures that the user input is safely included in the query without the risk of code injection.
  


- https://github.com/GeekMasherOrg/juice-shop/security/code-scanning/9
To fix the problem, we need to ensure that user input is properly sanitized and validated before being used in the MongoDB query. Instead of using the `$where` operator with a string concatenation, we can use a parameterized query to safely handle the user input. This will prevent any potential NoSQL injection attacks.

  We will modify the query to use a parameterized approach by directly comparing the `product` field with the `id` parameter. This change will be made in the `routes/showProductReviews.ts` file.
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
