### PR TITLE
Potential fixes for 4 code scanning alerts

### DIFF
--- a/routes/errorHandler.ts
+++ b/routes/errorHandler.ts
@@ -22,7 +22,17 @@ export function errorHandler () {
       return
     }
 
-    const template = await fs.readFile('views/errorPage.pug', { encoding: 'utf-8' })
+    const templatePath = 'views/errorPage.pug'
+    const template = await fs.readFile(templatePath, { encoding: 'utf-8' })
+    const crypto = await import('node:crypto')
+    const expectedHash = config.get<string>('templateHash') // Securely stored expected hash
+    const actualHash = crypto.createHash('sha256').update(template).digest('hex')
+
+    if (actualHash !== expectedHash) {
+      res.status(500).send('Template integrity check failed.')
+      return
+    }
+
     const title = `${config.get<string>('application.name')} (Express ${utils.version('express')})`
     const fn = pug.compile(template)
     res.status(500).send(fn({ title, error }))

--- a/routes/showProductReviews.ts
+++ b/routes/showProductReviews.ts
@@ -29,11 +29,14 @@ export function showProductReviews () {
   return (req: Request, res: Response, next: NextFunction) => {
     // Truncate id to avoid unintentional RCE
     const id = !utils.isChallengeEnabled(challenges.noSqlCommandChallenge) ? Number(req.params.id) : utils.trunc(req.params.id, 40)
+    if (isNaN(id)) {
+      return res.status(400).json({ error: 'Invalid product ID' })
+    }
 
     // Measure how long the query takes, to check if there was a nosql dos attack
     const t0 = new Date().getTime()
 
-    db.reviewsCollection.find({ $where: 'this.product == ' + id }).then((reviews: Review[]) => {
+    db.reviewsCollection.find({ product: id }).then((reviews: Review[]) => {
       const t1 = new Date().getTime()
       challengeUtils.solveIf(challenges.noSqlCommandChallenge, () => { return (t1 - t0) > 2000 })
       const user = security.authenticatedUsers.from(req)

--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fixes for 4 code scanning alerts from the [Testing](https://github.com/orgs/GeekMasherOrg/security/campaigns/8) security campaign:
- https://github.com/GeekMasherOrg/juice-shop/security/code-scanning/189
  <details>
    <summary>Suggested fix description</summary>
    
  </details>


- https://github.com/GeekMasherOrg/juice-shop/security/code-scanning/188
  <details>
    <summary>Suggested fix description</summary>
    To fix the issue, we should ensure that the Pug template file (`views/errorPage.pug`) is not tampered with before being compiled. This can be achieved by:
    1. Validating the integrity of the file using a cryptographic hash (e.g., SHA-256) to ensure it matches a known good value.
    2. Storing the expected hash value securely (e.g., in a configuration file or environment variable).
    3. Comparing the computed hash of the file content with the expected hash before compiling it with `pug.compile`.

    This approach ensures that even if the file is tampered with, the application will detect the modification and prevent the execution of potentially malicious code.
    
  </details>


- https://github.com/GeekMasherOrg/juice-shop/security/code-scanning/10
  <details>
    <summary>Suggested fix description</summary>
    To fix the issue, we should avoid using the `$where` operator with user-provided input, as it allows JavaScript code execution. Instead, we can rewrite the query to use a safer alternative, such as a direct field comparison with a parameterized query. This eliminates the need to evaluate JavaScript code and ensures that user input is treated as data, not code.

    Specifically:
    1. Replace the `$where` query with a direct query using the `orderId` field.
    2. Ensure that the `id` parameter is properly validated and sanitized to match the expected format of `orderId` in the database.

    ---
    
  </details>


- https://github.com/GeekMasherOrg/juice-shop/security/code-scanning/9
  <details>
    <summary>Suggested fix description</summary>
    To fix the issue, we need to prevent the user-provided `id` from being directly included in the `$where` query. Instead, we should use a safer query mechanism that avoids dynamic evaluation. Specifically:
    1. Validate and sanitize the `id` parameter to ensure it is a valid and expected value (e.g., a numeric or alphanumeric string).
    2. Replace the `$where` query with a standard MongoDB query that does not involve JavaScript evaluation. For example, use `{ product: id }` instead of `$where`.

    This fix ensures that the query is safe and does not execute arbitrary JavaScript code. The changes will be made in the `showProductReviews` function in `routes/showProductReviews.ts`.

    ---
    
  </details>


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
